### PR TITLE
adds prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,45 @@ AWS S3 returns a special hash for [multipart files](https://forums.aws.amazon.co
 ### setup
 see [here](dos_connect/server/README.md)
 
+#### server
+Setup: .env file
+
+```
+# ******* webserver
+# http port
+DOS_CONNECT_WEBSERVER_PORT=<port-number>
+# configure backend
+BACKEND=dos_connect.server.elastic_backend
+ELASTIC_URL=<url>
+# configure authorizer
+AUTHORIZER=dos_connect.server.keystone_api_key_authorizer
+# (/v3)
+DOS_SERVER_OS_AUTH_URL=<url>
+AUTHORIZER_PROJECTS=<project_name>
+# replicator
+REPLICATOR=dos_connect.server.kafka_replicator
+KAFKA_BOOTSTRAP_SERVERS=<url>
+KAFKA_DOS_TOPIC=<topic-name>
+```
+
+Server Startup:
+```
+$ alias web='docker-compose -f docker-compose-webserver.yml'
+$ web build ; web up -d
+```
+
+Client Startup:
+**note:** execute `source <openstack-openrc.sh>` first
+```
+# webserver endpoint
+export DOS_SERVER=<url>
+# sleep in between inventory runs
+export SLEEP=<seconds-to-sleep>
+# bucket to monitor
+export BUCKET_NAME=<existing-bucket-name>
+$ alias client='docker-compose -f docker-compose-swift.yml'
+$ client build; client up -d
+```
 
 ### ohsu implementation:
 

--- a/dos_connect/server/README.md
+++ b/dos_connect/server/README.md
@@ -108,10 +108,10 @@ sudo \
 
 ### server
 ```
-# user.htpasswd needs to exist in default dir
+# defaults to localhost:9200, set ELASTIC_URL=<url> to override
 sudo \  
   BACKEND=dos_connect.server.elasticsearch_backend  ES_REFRESH_ON_PERSIST=true \
-  python -dos_connect.server.app \
+  python -m dos_connect.server.app \
     -K $(pwd)/certs/certificate.key \
     -C $(pwd)/certs/certificate.pem  \
     -P 443

--- a/dos_connect/server/README.md
+++ b/dos_connect/server/README.md
@@ -127,3 +127,86 @@ sudo \
    --dos_server https://localhost \
    $AWS_TEST_BUCKET
 ```
+
+### ES index Setup
+
+curl -XPUT "http://elasticsearch:9200/data_objects/_mapping/data_object" -H 'Content-Type: application/json' -d'
+{"properties": {
+          "checksums": {
+            "properties": {
+              "checksum": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "type": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
+          },
+          "created": {
+            "type": "date"
+          },
+          "id": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "name": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "size": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "updated": {
+            "type": "date"
+          },
+          "urls": {
+            "properties": {
+              "url": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
+          },
+          "version": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }}'

--- a/dos_connect/server/controllers.py
+++ b/dos_connect/server/controllers.py
@@ -23,6 +23,7 @@ save = getattr(backend, 'save')
 update = getattr(backend, 'update')
 delete = getattr(backend, 'delete')
 search = getattr(backend, 'search')
+metrics = getattr(backend, 'metrics')
 
 # from replicator import replicate
 replicator_name = os.getenv('REPLICATOR', 'dos_connect.server.noop_replicator')
@@ -242,7 +243,7 @@ def DeleteDataBundle(**kwargs):
     """
     properties = AttributeDict({'id': kwargs['data_bundle_id']})
     delete(properties, 'data_bundles')
-    replicate(data_bundle, 'DELETE')
+    replicate(properties, 'DELETE')
     return(kwargs, 200)
 
 

--- a/dos_connect/server/elasticsearch_backend.py
+++ b/dos_connect/server/elasticsearch_backend.py
@@ -11,7 +11,7 @@ import uuid
 
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search, Q
-
+import elasticsearch
 from utils import AttributeDict, now, add_created_timestamps, \
                   add_updated_timestamps
 
@@ -136,10 +136,13 @@ def metrics(indexes=['data_objects', 'data_bundles']):
         try:
             s = Search(using=client, index=index, doc_type=index[:-1])
             return s.count()
+        except elasticsearch.exceptions.NotFoundError as no_found:
+            log.info('NotFoundError {} (expected on empty db)'.format(index))
+            return 0
         except Exception as e:
             log.error('error getting count of documents in {}'.format(index))
             log.exception(e)
-            return 0
+            raise e
     return [
         AttributeDict(
             {'name': index, 'count': _count(index)}

--- a/dos_connect/server/elasticsearch_backend.py
+++ b/dos_connect/server/elasticsearch_backend.py
@@ -126,3 +126,22 @@ def delete(properties, index='data_objects'):
         clauses.append('+{}:"{}"'.format(k, v))
     s = s.query("query_string", query=' '.join(clauses))
     s.delete()
+
+
+def metrics(indexes=['data_objects', 'data_bundles']):
+    """
+    return document counts
+    """
+    def _count(index):
+        try:
+            s = Search(using=client, index=index, doc_type=index[:-1])
+            return s.count()
+        except Exception as e:
+            log.error('error getting count of documents in {}'.format(index))
+            log.exception(e)
+            return 0
+    return [
+        AttributeDict(
+            {'name': index, 'count': _count(index)}
+            ) for index in indexes
+        ]

--- a/dos_connect/server/memory_backend.py
+++ b/dos_connect/server/memory_backend.py
@@ -133,3 +133,14 @@ def delete(properties, index='data_objects'):
             indexes.append(i)
     for i in sorted(indexes, reverse=True):
         del store[index][i]
+
+
+def metrics(indexes=['data_objects', 'data_bundle']):
+    """
+    return document counts
+    """
+    return [
+        AttributeDict(
+            {'name': index, 'count': len(store.get(index, []))}
+            ) for index in indexes
+        ]

--- a/dos_connect/server/requirements.txt
+++ b/dos_connect/server/requirements.txt
@@ -9,3 +9,5 @@ kafka-python==1.3.3
 passlib==1.7.1
 # for all authorizers
 decorator==4.0.11
+# for metrics
+prometheus-client==0.1.1

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -3,15 +3,16 @@ import logging
 import sys
 import os
 import uuid
+import requests
 
 # setup connection, models and security
 from bravado.requests_client import RequestsClient
 from dos_connect.client.dos_client import Client
-
+SERVER_URL = 'http://localhost:8080/'
 http_client = RequestsClient()
 # http_client.set_basic_auth('localhost', 'admin', 'secret')
 # http_client.set_api_key('localhost', 'XXX-YYY-ZZZ', param_in='header')
-local_client = Client('http://localhost:8080/', http_client=http_client)
+local_client = Client(SERVER_URL, http_client=http_client)
 client = local_client.client
 models = local_client.models
 
@@ -41,8 +42,6 @@ def test_client_driven_id():
     create_response = client.CreateDataObject(body=create_request).result()
     data_object_id = create_response['data_object_id']
     assert data_object_id == id,  "expected server to use client's id"
-
-
 
 
 def test_duplicate_checksums():
@@ -460,3 +459,15 @@ def test_data_bundles():
     alias_list_response = client.ListDataBundles(body=list_request).result()
     print(list_response.data_bundles[0].aliases[0])
     print(alias_list_response.data_bundles[0].aliases[0])
+
+
+def test_metrics():
+    print("..........OHSU metrics..............")
+    r = requests.get(SERVER_URL + 'metrics')
+    assert r.status_code == 200, '/metrics should return 200'
+    assert 'text/html' in r.headers['content-type'], \
+        'content-type should be text/html'
+    assert 'dos_connect_data_bundles_count' in r.text, \
+        'should return dos_connect_data_bundles_count'
+    assert 'dos_connect_data_objects_count' in r.text, \
+        'should return dos_connect_data_objects_count'


### PR DESCRIPTION
@buchanae  @kellrott @adamstruck  @prismofeverything : This dos_connect PR adds a  prometheus metrics endpoint `/metrics` and updates deployment documentation.

addresses:
https://github.com/ohsu-comp-bio/exastack/issues/14
https://github.com/ohsu-comp-bio/exastack/issues/18

e.g.
```
$ curl localhost:8080/metrics
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="2",minor="7",patchlevel="13",version="2.7.13"} 1.0
# HELP dos_connect_data_bundles_count Number of data_bundles
# TYPE dos_connect_data_bundles_count gauge
dos_connect_data_bundles_count 100.0
# HELP dos_connect_data_objects_count Number of data_objects
# TYPE dos_connect_data_objects_count gauge
dos_connect_data_objects_count 4729.0
```


