### PR TITLE
add 401,404,500 status

### DIFF
--- a/dos_connect/server/data_objects_service.swagger.json
+++ b/dos_connect/server/data_objects_service.swagger.json
@@ -29,6 +29,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghCreateDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -57,6 +66,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghListDataBundlesResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -85,6 +103,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -116,6 +143,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghDeleteDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -140,6 +176,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghUpdateDataBundleResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -173,6 +218,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataBundleVersionsResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -199,6 +253,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghCreateDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -227,6 +290,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghListDataObjectsResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -255,6 +327,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -286,6 +367,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghDeleteDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -310,6 +400,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghUpdateDataObjectResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [
@@ -343,6 +442,15 @@
             "schema": {
               "$ref": "#/definitions/ga4ghGetDataObjectVersionsResponse"
             }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid."
+          },
+          "404": {
+            "description": "Not found."
+          },
+          "500": {
+            "description": "Unexpected error."
           }
         },
         "parameters": [

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -4,10 +4,13 @@ import sys
 import os
 import uuid
 import requests
+import pytest
 
 # setup connection, models and security
 from bravado.requests_client import RequestsClient
+from bravado.exception import HTTPNotFound
 from dos_connect.client.dos_client import Client
+
 SERVER_URL = 'http://localhost:8080/'
 http_client = RequestsClient()
 # http_client.set_basic_auth('localhost', 'admin', 'secret')
@@ -471,3 +474,13 @@ def test_metrics():
         'should return dos_connect_data_bundles_count'
     assert 'dos_connect_data_objects_count' in r.text, \
         'should return dos_connect_data_objects_count'
+
+
+def test_no_find():
+    # this should raise an expected error
+    with pytest.raises(HTTPNotFound) as e:
+        get_bundle_response = client.GetDataBundle(
+            data_bundle_id='NON-EXISTING-KEY').result()
+        data_bundle = get_bundle_response.data_bundle
+        print(data_bundle)
+        print(data_bundle.id)


### PR DESCRIPTION
This PR adds http status codes to the expected response for all dos endpoints.
It is preparation for a contribution back to data-object-schemas as a replacement for https://github.com/ga4gh/data-object-service-schemas/blob/master/swagger/data_objects_service.swagger.json